### PR TITLE
Fix initial config file state bug

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -60,14 +60,20 @@ jobs:
     strategy:
       matrix:
         exclude:
+          - ruby: '2.6'
+            puppet: '< 6.0.0'
           - ruby: '2.5'
             puppet: '< 6.0.0'
+          - ruby: '2.4'
+            puppet: '< 8.0.0'
         puppet:
           - '< 6.0.0'
           - '< 7.0.0'
+          - '< 8.0.0'
         ruby:
           - '2.4'
           - '2.5'
+          - '2.6'
     steps:
       - name: 'Checkout repo'
         uses: 'actions/checkout@v2.4.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,7 @@ class sentinelone_agent (
   String $service_name,
   String $token,
 ) {
-  contain 'sentinelone_agent::config'
   contain 'sentinelone_agent::install'
+  contain 'sentinelone_agent::config'
   contain 'sentinelone_agent::service'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.0.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -38,6 +38,24 @@ describe 'sentinelone_agent' do
             )
           end
           it do
+            is_expected.to contain_file('/opt/sentinelone/configuration/basic.conf').with(
+              ensure: 'file',
+              group: 'sentinelone',
+              mode: '0600',
+              owner: 'sentinelone',
+              require: 'Package[sentinelone_agent_package]',
+            )
+          end
+          it do
+            is_expected.to contain_exec('initialize_basic_conf').with(
+              command: "echo '{}' > /opt/sentinelone/configuration/basic.conf",
+              path: '/bin:/usr/bin:/sbin:/usr/sbin',
+              refreshonly: true,
+              subscribe: 'File[/opt/sentinelone/configuration/basic.conf]',
+              unless: 'test -s /opt/sentinelone/configuration/basic.conf',
+            )
+          end
+          it do
             is_expected.to contain_service('sentinelone_agent_service').with(
               enable: true,
               ensure: 'running',

--- a/spec/defines/option_spec.rb
+++ b/spec/defines/option_spec.rb
@@ -22,16 +22,32 @@ describe 'sentinelone_agent::option' do
             end
 
             it do
-              is_expected.to contain_augeas('sentinelone_agent_option_mgmt_proxy_url').with(
+              is_expected.to contain_augeas('sentinelone_agent_option_add_mgmt_proxy_url').with(
+                changes: [
+                  'set dict/entry[last()+1] mgmt_proxy_url',
+                  "set dict/entry[.= 'mgmt_proxy_url']/string 'http://example.com:8888'",
+                ],
+                context: '/files/opt/sentinelone/configuration/basic.conf',
+                incl: '/opt/sentinelone/configuration/basic.conf',
+                lens: 'Json.lns',
+                onlyif: "match dict/entry[.= 'mgmt_proxy_url'] size == 0",
+                notify: 'Service[sentinelone_agent_service]',
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
+              )
+            end
+            it do
+              is_expected.to contain_augeas('sentinelone_agent_option_update_mgmt_proxy_url').with(
                 changes: "set dict/entry[.= 'mgmt_proxy_url']/string 'http://example.com:8888'",
                 context: '/files/opt/sentinelone/configuration/basic.conf',
                 incl: '/opt/sentinelone/configuration/basic.conf',
                 lens: 'Json.lns',
                 onlyif: "get dict/entry[.= 'mgmt_proxy_url']/string != 'http://example.com:8888'",
                 notify: 'Service[sentinelone_agent_service]',
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
               )
             end
           end
+
           context 'with a value and custom setting name' do
             let(:params) { { setting: 'new_proxy_url', value: 'http://example.com:8888' } }
 
@@ -40,13 +56,28 @@ describe 'sentinelone_agent::option' do
             end
 
             it do
-              is_expected.to contain_augeas('sentinelone_agent_option_new_proxy_url').with(
+              is_expected.to contain_augeas('sentinelone_agent_option_add_new_proxy_url').with(
+                changes: [
+                  'set dict/entry[last()+1] new_proxy_url',
+                  "set dict/entry[.= 'new_proxy_url']/string 'http://example.com:8888'",
+                ],
+                context: '/files/opt/sentinelone/configuration/basic.conf',
+                incl: '/opt/sentinelone/configuration/basic.conf',
+                lens: 'Json.lns',
+                onlyif: "match dict/entry[.= 'new_proxy_url'] size == 0",
+                notify: 'Service[sentinelone_agent_service]',
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
+              )
+            end
+            it do
+              is_expected.to contain_augeas('sentinelone_agent_option_update_new_proxy_url').with(
                 changes: "set dict/entry[.= 'new_proxy_url']/string 'http://example.com:8888'",
                 context: '/files/opt/sentinelone/configuration/basic.conf',
                 incl: '/opt/sentinelone/configuration/basic.conf',
                 lens: 'Json.lns',
                 onlyif: "get dict/entry[.= 'new_proxy_url']/string != 'http://example.com:8888'",
                 notify: 'Service[sentinelone_agent_service]',
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
               )
             end
           end
@@ -73,13 +104,28 @@ describe 'sentinelone_agent::option' do
             end
 
             it do
-              is_expected.to contain_augeas('sentinelone_agent_option_mgmt_proxy_url').with(
+              is_expected.to contain_augeas('sentinelone_agent_option_add_mgmt_proxy_url').with(
+                changes: [
+                  'set dict/entry[last()+1] mgmt_proxy_url',
+                  "set dict/entry[.= 'mgmt_proxy_url']/string 'http://example.com:8888'",
+                ],
+                context: '/files/opt/sentinelone/configuration/basic.conf',
+                incl: '/opt/sentinelone/configuration/basic.conf',
+                lens: 'Json.lns',
+                onlyif: "match dict/entry[.= 'mgmt_proxy_url'] size == 0",
+                notify: nil,
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
+              )
+            end
+            it do
+              is_expected.to contain_augeas('sentinelone_agent_option_update_mgmt_proxy_url').with(
                 changes: "set dict/entry[.= 'mgmt_proxy_url']/string 'http://example.com:8888'",
                 context: '/files/opt/sentinelone/configuration/basic.conf',
                 incl: '/opt/sentinelone/configuration/basic.conf',
                 lens: 'Json.lns',
                 onlyif: "get dict/entry[.= 'mgmt_proxy_url']/string != 'http://example.com:8888'",
                 notify: nil,
+                require: 'File[/opt/sentinelone/configuration/basic.conf]',
               )
             end
           end


### PR DESCRIPTION
* Fix initial config file state bug
* Add Puppet 7 / Ruby 2.6 testing
* Manage the `/opt/sentinelone/configuration/basic.conf` config file for presence and permissions only
* Add an augeas rule to add a new config entry if the key doesn't yet exist
* Update unit tests for changes