### PR TITLE
Upgrade dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 1.0.0 < 9.0.0"
     },
     {
       "name": "puppet/logrotate",

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/logrotate",
-      "version_requirement": "> 3.4.0 < 6.0.0"
+      "version_requirement": "> 3.4.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Use the latest of modules `stdlib` and `logrotate` so i can install other modules with dependency sdtlib >= 7 (puppetboard in my case)