### PR TITLE
Update for stdlib 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 9.0.0"
+      "version_requirement": ">= 1.0.0 < 10.0.0"
     },
     {
       "name": "puppet/logrotate",
-      "version_requirement": "> 3.4.0 < 7.0.0"
+      "version_requirement": "> 3.4.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
logrotate > 7 also depens on stdlib < 9.0.0, so it also requires the version bump